### PR TITLE
bug fix for global state management

### DIFF
--- a/dist/z.js
+++ b/dist/z.js
@@ -1101,9 +1101,9 @@ function useStore(store) {
     id: store.id,
     current: () => store.getValue(),
     subscribe: (fn) => store.subscribe(fn),
-    value: store.getState()
+    value: store.getValue
   };
-  const setState = store.setState;
+  const setState = store.setValue;
   return [state, setState, store.channel];
 }
 class ZLink extends HTMLElement {


### PR DESCRIPTION
changed `store.getState` and `store.setState` to `store.getValue` and `store.setValue` respectively...
fixes #6